### PR TITLE
Add decoded size determination

### DIFF
--- a/examples/2-unittest-Base64/2-unittest-Base64.cpp
+++ b/examples/2-unittest-Base64/2-unittest-Base64.cpp
@@ -86,7 +86,16 @@ void runTests() {
 
 		bool success = Base64::encode(testEntries[testNum].data, testEntries[testNum].dataLen, encoded, encodedLen, true);
 		if (success) {
-			if (strcmp(encoded, testEntries[testNum].enc) == 0) {
+			if (strcmp(encoded, testEntries[testNum].enc) == 0) {				
+				// Test getDecodedSize
+				size_t preciseDecodedLen = Base64::getDecodedSize(testEntries[testNum].enc);
+				if (preciseDecodedLen == testEntries[testNum].dataLen) {
+
+				}
+				else {
+					DEBUG_PRINT("test %lu decode length mismatch got %lu expected %lu\n", testNum, preciseDecodedLen, testEntries[testNum].dataLen);
+				}
+
 				// Successfully encoded
 				size_t srcLen = strlen(encoded);
 

--- a/src/Base64RK.cpp
+++ b/src/Base64RK.cpp
@@ -177,3 +177,17 @@ size_t Base64::getMaxDecodedSize(size_t srcLen) {
 
 	return numQuads * 3;
 }
+
+// [static]
+size_t Base64::getDecodedSize(String srcString) {
+	size_t srcLen = srcString.length();
+	size_t paddingCount = (size_t)(srcString.charAt(srcLen - 1) == '=') + (srcString.charAt(srcLen - 2) == '=');
+	size_t numQuads = srcString.length() / 4;
+
+	return (numQuads* 3) - paddingCount;
+}
+
+// [static]
+size_t Base64::getDecodedSize(const char *src) {
+	return getDecodedSize(String(src));
+}

--- a/src/Base64RK.h
+++ b/src/Base64RK.h
@@ -122,6 +122,28 @@ public:
 	 */
 	static size_t getMaxDecodedSize(size_t srcLen);
 
+	/**
+	 * @brief Get the size(in bytes) of the decoded data, given Base64 encoded String srcString
+	 *  
+	 * This is ((srcLen + 3) / 4) * 3 - padding count. This will return an accurate number of bytes 
+	 * for the decodded data.
+	 * 
+	 * @param srcString Base64 encoded string
+	 * @return size_t size(in bytes) of decoded data
+	 */
+	static size_t getDecodedSize(String srcString);
+
+	/**
+	 * @brief Get the size(in bytes) of the decoded data, given Base64 encoded byte array src
+	 *  
+	 * This is ((srcLen + 3) / 4) * 3 - padding count. This will return an accurate number of bytes 
+	 * for the decodded data.
+	 * 
+	 * @param src Base64 encoded bytes
+	 * @return size_t size(in bytes) of decoded data
+	 */
+	static size_t getDecodedSize(const char *src);
+
 private:
 	static const char *encodeTable;
 	static const uint8_t decodeTable[];


### PR DESCRIPTION
# Description of changes
This pull request just adds a method to return the decoded size of either an encoded  `spark_wiring_string.h` String, or an overload that will return the decoded size of a C string

### How has this been tested?
By flashing the unittest 2 sketch to an argon, and running the tests that I added to it